### PR TITLE
Add clustering API support

### DIFF
--- a/pulse/core/client.py
+++ b/pulse/core/client.py
@@ -16,6 +16,7 @@ from pulse.core.models import (
     SentimentResponse,
     ExtractionsResponse,
     JobSubmissionResponse,
+    ClusteringResponse,
 )
 from pulse.core.exceptions import PulseAPIError
 
@@ -526,3 +527,40 @@ class CoreClient:
 
         # Sync path
         return ExtractionsResponse.model_validate(data)
+
+    def cluster_texts(
+        self,
+        inputs: list[str],
+        *,
+        k: int,
+        algorithm: str | None = None,
+        fast: bool | None = None,
+        await_job_result: bool = True,
+    ) -> Union[ClusteringResponse, Job]:
+        """Cluster texts into groups using embeddings."""
+
+        body: Dict[str, Any] = {"inputs": inputs, "k": k}
+        if algorithm is not None:
+            body["algorithm"] = algorithm
+        if fast is not None:
+            body["fast"] = fast
+
+        response = self.client.post("/clustering", json=body)
+
+        if response.status_code not in (200, 202):
+            raise PulseAPIError(response)
+
+        data = response.json()
+
+        if response.status_code == 202:
+            if fast:
+                raise PulseAPIError(response)
+            submission = JobSubmissionResponse.model_validate(data)
+            job = Job(id=submission.jobId, status="pending")
+            job._client = self.client
+            if not await_job_result:
+                return job
+            result = job.wait()
+            return ClusteringResponse.model_validate(result)
+
+        return ClusteringResponse.model_validate(data)

--- a/pulse/core/models.py
+++ b/pulse/core/models.py
@@ -182,3 +182,33 @@ class JobStatusResponse(BaseModel):
     message: Optional[str] = Field(
         None, description="Error message if jobStatus is error or failed"
     )
+
+
+class ClusteringRequest(BaseModel):
+    """Request model for text clustering."""
+
+    inputs: List[str] = Field(..., min_length=2, description="Input texts")
+    k: int = Field(..., ge=1, le=50, description="Number of clusters")
+    algorithm: Optional[
+        Literal["kmeans", "skmeans", "agglomerative", "hdbscan"]
+    ] = Field(None, description="Clustering algorithm")
+    fast: Optional[bool] = Field(
+        None, description="Synchronous (True) or asynchronous (False)"
+    )
+
+
+class Cluster(BaseModel):
+    """Single cluster grouping."""
+
+    clusterId: int = Field(..., description="Cluster identifier")
+    items: List[str] = Field(..., description="Items assigned to this cluster")
+
+
+class ClusteringResponse(BaseModel):
+    """Response model for clustering request."""
+
+    algorithm: str = Field(..., description="Algorithm used for clustering")
+    clusters: List[Cluster] = Field(..., description="List of cluster groups")
+    requestId: Optional[str] = Field(
+        None, description="Unique request identifier"
+    )

--- a/pulse/starters.py
+++ b/pulse/starters.py
@@ -3,10 +3,12 @@ from typing import List, Union
 import pandas as pd
 from typing import Optional
 from pulse.analysis.analyzer import Analyzer
-from pulse.analysis.processes import Cluster, SentimentProcess, ThemeAllocation
-from pulse.analysis.results import ClusterResult, SentimentResult, ThemeAllocationResult
+from pulse.analysis.processes import SentimentProcess, ThemeAllocation
+from pulse.analysis.results import SentimentResult, ThemeAllocationResult
 from pulse.auth import _BaseOAuth2Auth
 from pulse.core.client import CoreClient
+from pulse.core.jobs import Job
+from pulse.core.models import ClusteringResponse
 
 
 def _load_csv_tsv(path: str) -> List[str]:
@@ -100,21 +102,24 @@ def theme_allocation(
 
 def cluster_analysis(
     input_data: Union[List[str], str],
+    *,
+    k: int,
+    algorithm: str | None = None,
+    await_job_result: bool = True,
     auth: _BaseOAuth2Auth | None = None,
     client: Optional[CoreClient] = None,
-) -> ClusterResult:
-    """
-    Perform clustering analysis on input data.
-    Returns a ClusterResult object.
-    """
-    texts = get_strings(input_data)
+) -> Union[ClusteringResponse, Job]:
+    """Cluster input texts using the core API."""
 
+    texts = get_strings(input_data)
     fast = len(texts) <= 200
 
-    analyzer = Analyzer(
-        processes=[Cluster()], dataset=texts, client=client, fast=fast, auth=auth
+    client = client or CoreClient(auth=auth)
+
+    return client.cluster_texts(
+        texts,
+        k=k,
+        algorithm=algorithm,
+        fast=fast,
+        await_job_result=await_job_result,
     )
-
-    resp = analyzer.run()
-
-    return resp.cluster

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -1,0 +1,84 @@
+import time
+import httpx
+from pulse.core.client import CoreClient
+from pulse.core.models import ClusteringResponse
+from pulse.core.jobs import Job
+
+
+def make_sync_client():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/clustering"
+        return httpx.Response(
+            200,
+            json={
+                "algorithm": "kmeans",
+                "clusters": [
+                    {"clusterId": 0, "items": ["a"]},
+                    {"clusterId": 1, "items": ["b"]},
+                ],
+                "requestId": "r1",
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport, base_url="https://api.example.com")
+    return CoreClient(client=client)
+
+
+def make_async_client():
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path == "/clustering":
+            return httpx.Response(202, json={"jobId": "job123"})
+        if request.method == "GET" and request.url.path == "/jobs":
+            return httpx.Response(
+                200,
+                json={
+                    "jobId": "job123",
+                    "jobStatus": "completed",
+                    "resultUrl": "https://api.example.com/results/job123",
+                },
+            )
+        if request.method == "GET" and request.url.path == "/results/job123":
+            return httpx.Response(
+                200,
+                json={
+                    "algorithm": "kmeans",
+                    "clusters": [
+                        {"clusterId": 0, "items": ["a", "b"]}
+                    ],
+                    "requestId": "r2",
+                },
+            )
+        raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport, base_url="https://api.example.com")
+    return CoreClient(client=client)
+
+
+def test_cluster_texts_sync():
+    client = make_sync_client()
+    resp = client.cluster_texts(["a", "b"], k=2, fast=True)
+    assert isinstance(resp, ClusteringResponse)
+    assert len(resp.clusters) == 2
+    assert resp.clusters[0].items == ["a"]
+
+
+def test_cluster_texts_async_job(monkeypatch):
+    client = make_async_client()
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    job = client.cluster_texts(["a", "b"], k=1, await_job_result=False)
+    assert isinstance(job, Job)
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    result = job.wait()
+    assert result["algorithm"] == "kmeans"
+
+
+def test_cluster_texts_async_wait(monkeypatch):
+    client = make_async_client()
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    resp = client.cluster_texts(["a", "b"], k=1, await_job_result=True)
+    assert isinstance(resp, ClusteringResponse)
+    assert resp.algorithm == "kmeans"
+
+

--- a/tests/test_starters.py
+++ b/tests/test_starters.py
@@ -3,8 +3,8 @@
 import os
 import pandas as pd
 import pytest
+import httpx
 
-from pulse.analysis.results import ClusterResult
 from pulse.auth import ClientCredentialsAuth
 from pulse.config import DEV_BASE_URL
 from pulse.core.client import CoreClient
@@ -132,10 +132,24 @@ def test_theme_allocation_with_themes():
     assert isinstance(df, pd.DataFrame)
 
 
-@pytest.mark.vcr()
 def test_cluster_analysis():
     from pulse.starters import cluster_analysis
+    from pulse.core.models import ClusteringResponse
 
-    resp = cluster_analysis(reviews, client=client)
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/clustering"
+        return httpx.Response(
+            200,
+            json={
+                "algorithm": "kmeans",
+                "clusters": [{"clusterId": 0, "items": reviews[:2]}],
+                "requestId": "r1",
+            },
+        )
 
-    assert isinstance(resp, ClusterResult)
+    transport = httpx.MockTransport(handler)
+    fake_client = CoreClient(client=httpx.Client(transport=transport, base_url="https://api.example.com"))
+
+    resp = cluster_analysis(reviews, k=1, client=fake_client)
+
+    assert isinstance(resp, ClusteringResponse)


### PR DESCRIPTION
## Summary
- add models for clustering requests/responses
- implement CoreClient.cluster_texts()
- update cluster_analysis starter to call new endpoint
- test new clustering helper for sync/async
- adjust starter tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_68829d8d56948329a78465e71b78e38f