### PR TITLE
Add summaries endpoint support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ client = CoreClient(auth=auth)
 resp = client.create_embeddings(["Hello world", "Goodbye"])
 ```
 
+### Summarize text
+
+```python
+from pulse.starters import summarize
+
+texts = ["Great service and friendly staff!", "The app crashed repeatedly."]
+summary = summarize(texts, question="What do people think?")
+print(summary.summary)
+```
+
 ### Analyzer
 ```python
 from pulse.analysis.analyzer import Analyzer

--- a/pulse/core/client.py
+++ b/pulse/core/client.py
@@ -17,6 +17,7 @@ from pulse.core.models import (
     ExtractionsResponse,
     JobSubmissionResponse,
     ClusteringResponse,
+    SummariesResponse,
 )
 from pulse.core.exceptions import PulseAPIError
 
@@ -564,3 +565,43 @@ class CoreClient:
             return ClusteringResponse.model_validate(result)
 
         return ClusteringResponse.model_validate(data)
+
+    def generate_summary(
+        self,
+        inputs: list[str],
+        question: str,
+        *,
+        length: str | None = None,
+        preset: str | None = None,
+        fast: bool | None = None,
+        await_job_result: bool = True,
+    ) -> Union[SummariesResponse, Job]:
+        """Summarize text according to a question."""
+
+        body: Dict[str, Any] = {"inputs": inputs, "question": question}
+        if length is not None:
+            body["length"] = length
+        if preset is not None:
+            body["preset"] = preset
+        if fast is not None:
+            body["fast"] = fast
+
+        response = self.client.post("/summaries", json=body)
+
+        if response.status_code not in (200, 202):
+            raise PulseAPIError(response)
+
+        data = response.json()
+
+        if response.status_code == 202:
+            if fast:
+                raise PulseAPIError(response)
+            submission = JobSubmissionResponse.model_validate(data)
+            job = Job(id=submission.jobId, status="pending")
+            job._client = self.client
+            if not await_job_result:
+                return job
+            result = job.wait()
+            return SummariesResponse.model_validate(result)
+
+        return SummariesResponse.model_validate(data)

--- a/pulse/core/models.py
+++ b/pulse/core/models.py
@@ -1,4 +1,5 @@
 """Pydantic models for Pulse API responses."""
+
 from typing import List, Optional, Literal
 from pydantic import BaseModel, Field, model_validator
 
@@ -189,9 +190,9 @@ class ClusteringRequest(BaseModel):
 
     inputs: List[str] = Field(..., min_length=2, description="Input texts")
     k: int = Field(..., ge=1, le=50, description="Number of clusters")
-    algorithm: Optional[
-        Literal["kmeans", "skmeans", "agglomerative", "hdbscan"]
-    ] = Field(None, description="Clustering algorithm")
+    algorithm: Optional[Literal["kmeans", "skmeans", "agglomerative", "hdbscan"]] = (
+        Field(None, description="Clustering algorithm")
+    )
     fast: Optional[bool] = Field(
         None, description="Synchronous (True) or asynchronous (False)"
     )
@@ -209,4 +210,36 @@ class ClusteringResponse(BaseModel):
 
     algorithm: str = Field(..., description="Algorithm used for clustering")
     clusters: List[Cluster] = Field(..., description="List of cluster groups")
+    requestId: Optional[str] = Field(None, description="Unique request identifier")
+
+
+class SummariesRequest(BaseModel):
+    """Request model for text summarization."""
+
+    inputs: List[str] = Field(..., min_length=1, description="Input texts")
+    question: str = Field(..., description="Question to guide the summary")
+    length: Optional[Literal["bullet-points", "short", "medium", "long"]] = Field(
+        None, description="Desired summary length"
+    )
+    preset: Optional[
+        Literal[
+            "five-point",
+            "ten-point",
+            "one-tweet",
+            "three-tweets",
+            "one-para",
+            "exec",
+            "two-pager",
+            "one-pager",
+        ]
+    ] = Field(None, description="Predefined summary style")
+    fast: Optional[bool] = Field(
+        None, description="Synchronous (True) or asynchronous (False)"
+    )
+
+
+class SummariesResponse(BaseModel):
+    """Response model for text summarization."""
+
+    summary: str = Field(..., description="Generated summary text")
     requestId: Optional[str] = Field(None, description="Unique request identifier")

--- a/pulse/starters.py
+++ b/pulse/starters.py
@@ -8,7 +8,7 @@ from pulse.analysis.results import SentimentResult, ThemeAllocationResult
 from pulse.auth import _BaseOAuth2Auth
 from pulse.core.client import CoreClient
 from pulse.core.jobs import Job
-from pulse.core.models import ClusteringResponse
+from pulse.core.models import ClusteringResponse, SummariesResponse
 
 
 def _load_csv_tsv(path: str) -> List[str]:
@@ -120,6 +120,33 @@ def cluster_analysis(
         texts,
         k=k,
         algorithm=algorithm,
+        fast=fast,
+        await_job_result=await_job_result,
+    )
+
+
+def summarize(
+    input_data: Union[List[str], str],
+    question: str,
+    *,
+    length: str | None = None,
+    preset: str | None = None,
+    await_job_result: bool = True,
+    auth: _BaseOAuth2Auth | None = None,
+    client: Optional[CoreClient] = None,
+) -> Union[SummariesResponse, Job]:
+    """Generate a summary of the provided texts."""
+
+    texts = get_strings(input_data)
+    fast = len(texts) <= 200
+
+    client = client or CoreClient(auth=auth)
+
+    return client.generate_summary(
+        texts,
+        question,
+        length=length,
+        preset=preset,
         fast=fast,
         await_job_result=await_job_result,
     )

--- a/tests/test_summaries.py
+++ b/tests/test_summaries.py
@@ -1,0 +1,66 @@
+import time
+import httpx
+from pulse.core.client import CoreClient
+from pulse.core.models import SummariesResponse
+from pulse.core.jobs import Job
+
+
+def make_sync_client():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/summaries"
+        data = {"summary": "foo", "requestId": "r1"}
+        return httpx.Response(200, json=data)
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport, base_url="https://api.example.com")
+    return CoreClient(client=client)
+
+
+def make_async_client():
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path == "/summaries":
+            return httpx.Response(202, json={"jobId": "job123"})
+        if request.method == "GET" and request.url.path == "/jobs":
+            return httpx.Response(
+                200,
+                json={
+                    "jobId": "job123",
+                    "jobStatus": "completed",
+                    "resultUrl": "https://api.example.com/results/job123",
+                },
+            )
+        if request.method == "GET" and request.url.path == "/results/job123":
+            return httpx.Response(
+                200,
+                json={"summary": "bar", "requestId": "r2"},
+            )
+        raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport, base_url="https://api.example.com")
+    return CoreClient(client=client)
+
+
+def test_generate_summary_sync():
+    client = make_sync_client()
+    resp = client.generate_summary(["a"], "question", fast=True)
+    assert isinstance(resp, SummariesResponse)
+    assert resp.summary == "foo"
+
+
+def test_generate_summary_async_job(monkeypatch):
+    client = make_async_client()
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    job = client.generate_summary(["a"], "q", await_job_result=False)
+    assert isinstance(job, Job)
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    result = job.wait()
+    assert result["summary"] == "bar"
+
+
+def test_generate_summary_async_wait(monkeypatch):
+    client = make_async_client()
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    resp = client.generate_summary(["a"], "q", await_job_result=True)
+    assert isinstance(resp, SummariesResponse)
+    assert resp.summary == "bar"


### PR DESCRIPTION
## Summary
- support summarization in the core models and client
- expose `summarize` convenience helper
- document summarization in README
- test synchronous and async summary generation

## Testing
- `ruff check pulse/core/models.py pulse/core/client.py pulse/starters.py tests/test_summaries.py`
- `black pulse/core/models.py pulse/core/client.py pulse/starters.py tests/test_summaries.py`
- `pytest tests/test_summaries.py` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_688321f5dd8883299bb60e8dfc715e4f