### PR TITLE
Update extraction endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,18 @@ summary = summarize(texts, question="What do people think?")
 print(summary.summary)
 ```
 
+### Extract elements
+
+```python
+client = CoreClient()
+resp = client.extract_elements(
+    texts=["The food was great and the service was slow."],
+    categories=["food", "service"],
+    fast=True,
+)
+print(resp.extractions)
+```
+
 ### Analyzer
 ```python
 from pulse.analysis.analyzer import Analyzer

--- a/openapi.yml
+++ b/openapi.yml
@@ -2,7 +2,7 @@
 openapi: 3.1.0
 info:
     title: Pulse API
-    version: 0.6.0
+    version: 0.7.0
     description: |
         A stateless RESTful service that provides **six** core capabilities:
 
@@ -417,11 +417,11 @@ paths:
                 Extracts substrings from inputs that match the provided themes.
                 Supports synchronous (fast=true) and asynchronous (fast=false or omitted) modes.
 
-                 - Both modes support up to 200 input strings and up to 50 themes.
+                 - Both modes support up to 200 text strings and up to 50 categories.
                  - Synchronous mode returns extraction results immediately (HTTP 200).
                  - Asynchronous mode returns a job_id (HTTP 202) to poll via the /jobs endpoint.
 
-                Returns a 3-dimensional array where `extractions[i][j]` contains matching elements for input `i` and theme `j`.
+                Returns a 3-dimensional array where `extractions[i][j]` contains matching elements for text `i` and category `j`.
             tags: [extractions]
             requestBody:
                 required: true
@@ -433,8 +433,9 @@ paths:
                             Default:
                                 summary: Basic extractions request
                                 value:
-                                    inputs: ['The food was great and the service was slow.']
-                                    themes: ['food', 'service']
+                                    texts: ['The food was great and the service was slow.']
+                                    categories: ['food', 'service']
+                                    dictionary: true
             responses:
                 '200':
                     description: Extraction results returned successfully.
@@ -461,8 +462,8 @@ paths:
                                     summary: Sample validation error response
                                     value:
                                         message:
-                                            'Validation error: inputs must be an array of 1 to 200
-                                            strings and themes must be an array of 1 to 50 strings.'
+                                            'Validation error: texts must be an array of 1 to 200
+                                            strings and categories must be an array of 1 to 50 strings.'
 
     /summaries:
         post:
@@ -921,18 +922,21 @@ components:
         ExtractionsRequest:
             type: object
             properties:
-                inputs:
+                texts:
                     type: array
                     minItems: 1
                     maxItems: 200
                     items:
                         type: string
-                themes:
+                categories:
                     type: array
                     minItems: 1
                     maxItems: 50
                     items:
                         type: string
+                dictionary:
+                    type: boolean
+                    description: 'Enable dictionary-based extraction'
                 version:
                     type: string
                 fast:
@@ -940,7 +944,7 @@ components:
                     description:
                         Flag indicating synchronous (true) or asynchronous (false) processing.
                         Default false.
-            required: [inputs, themes]
+            required: [texts, categories]
             additionalProperties: false
 
         ExtractionsResponse:
@@ -949,7 +953,7 @@ components:
                 extractions:
                     type: array
                     description:
-                        3D array of extracted elements, shape [inputs.length][themes.length][K]
+                        3D array of extracted elements, shape [texts.length][categories.length][K]
                     maxItems: 1000
                     items:
                         type: array

--- a/pulse/core/client.py
+++ b/pulse/core/client.py
@@ -1,6 +1,7 @@
 """CoreClient for interacting with the Pulse API synchronously."""
 
 from typing import Any, Dict, List, Union, Optional
+import warnings
 import httpx
 from pulse.core.gzip_client import GzipClient
 from pulse.core.batching import _make_self_chunks, _make_cross_bodies, _stitch_results
@@ -483,50 +484,64 @@ class CoreClient:
 
     def extract_elements(
         self,
-        inputs: list[str],
-        themes: list[Union[str, Theme]],
-        version: Optional[str] = None,
-        fast: bool = True,
+        texts: list[str] | None = None,
+        categories: list[Union[str, Theme]] | None = None,
+        *,
+        version: str | None = None,
+        dictionary: bool | None = None,
+        fast: bool | None = None,
+        await_job_result: bool = True,
+        **legacy_kwargs: Any,
     ) -> Union[ExtractionsResponse, Job]:
-        """Extract elements matching themes from input strings."""
-        # Skip extraction when no themes provided
-        if not themes:
-            raise ValueError("Must provide at least one theme for extraction.")
+        """Extract elements matching categories from input texts."""
 
-        # Normalize themes: accept either Theme objects or raw strings
-        serialized_themes = [
-            t if isinstance(t, str) else t.label  # or t.id if that's the identifier
-            for t in themes
+        if "inputs" in legacy_kwargs and texts is None:
+            texts = legacy_kwargs.pop("inputs")
+        if "themes" in legacy_kwargs and categories is None:
+            warnings.warn(
+                "'themes' argument is deprecated; use 'categories' instead",
+                DeprecationWarning,
+            )
+            categories = legacy_kwargs.pop("themes")
+
+        if legacy_kwargs:
+            raise TypeError(f"Unexpected keyword arguments: {', '.join(legacy_kwargs)}")
+
+        if texts is None:
+            raise TypeError("'texts' parameter is required")
+        if categories is None:
+            raise TypeError("'categories' parameter is required")
+
+        serialized_categories = [
+            c if isinstance(c, str) else c.label for c in categories
         ]
 
-        # Build request body
-        body: Dict[str, Any] = {
-            "inputs": inputs,
-            "themes": serialized_themes,
-        }
+        body: Dict[str, Any] = {"texts": texts, "categories": serialized_categories}
         if version is not None:
             body["version"] = version
-        if fast:
-            body["fast"] = True
+        if dictionary is not None:
+            body["dictionary"] = dictionary
+        if fast is not None:
+            body["fast"] = fast
 
         response = self.client.post("/extractions", json=body)
+
         if response.status_code not in (200, 202):
             raise PulseAPIError(response)
+
         data = response.json()
 
-        # Fast-sync cannot enqueue an async job
-        if response.status_code == 202 and fast:
-            raise PulseAPIError(response)
-
-        # Async job path
         if response.status_code == 202:
+            if fast:
+                raise PulseAPIError(response)
             submission = JobSubmissionResponse.model_validate(data)
             job = Job(id=submission.jobId, status="pending")
             job._client = self.client
+            if not await_job_result:
+                return job
             result = job.wait()
             return ExtractionsResponse.model_validate(result)
 
-        # Sync path
         return ExtractionsResponse.model_validate(data)
 
     def cluster_texts(

--- a/pulse/core/models.py
+++ b/pulse/core/models.py
@@ -1,7 +1,7 @@
 """Pydantic models for Pulse API responses."""
 
 from typing import List, Optional, Literal
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, model_validator, ConfigDict
 
 
 class EmbeddingDocument(BaseModel):
@@ -155,11 +155,38 @@ class SentimentResponse(BaseModel):
         return [r.sentiment for r in self.results]
 
 
+class ExtractionsRequest(BaseModel):
+    """Request model for text element extraction."""
+
+    texts: List[str] = Field(..., min_length=1, description="Input texts")
+    categories: List[str] = Field(
+        ..., min_length=1, description="Categories to extract elements for"
+    )
+    dictionary: Optional[bool] = Field(
+        None, description="Enable dictionary-based extraction"
+    )
+    version: Optional[str] = Field(None, description="Extractor version")
+    fast: Optional[bool] = Field(
+        None, description="Synchronous (True) or asynchronous (False)"
+    )
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    @model_validator(mode="before")
+    def _normalize_legacy(cls, values: dict) -> dict:
+        if "inputs" in values and "texts" not in values:
+            values["texts"] = values.pop("inputs")
+        if "themes" in values and "categories" not in values:
+            values["categories"] = values.pop("themes")
+        return values
+
+
 class ExtractionsResponse(BaseModel):
     """Response model for text element extraction."""
 
     extractions: List[List[List[str]]] = Field(
-        ..., description="3D array of extracted elements, shape [inputs][themes][k]"
+        ...,
+        description="3D array of extracted elements, shape [texts][categories][k]",
     )
     requestId: Optional[str] = Field(None, description="Unique request identifier")
 


### PR DESCRIPTION
## Summary
- extend openapi spec with new extraction request parameters
- add `ExtractionsRequest` model and update response
- allow `CoreClient.extract_elements` to accept new schema
- include short example in README

## Testing
- `ruff check pulse`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688325592124832983236dfe0cd96ebf