### PR TITLE
Support categories in extractions

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -10,7 +10,7 @@ info:
           - Flexible cosine-similarity computations across strings.
           - Thematic clustering of open-ended text into concise, human-readable themes.
           - Sentiment classification of each input string.
-          - Extraction of text elements matching specified themes from input strings.
+          - Extraction of text elements matching specified categories from input strings.
           - Clustering of text into groups using vector embeddings.
 
         ### Similarity
@@ -88,8 +88,8 @@ tags:
           - In asynchronous mode, accepts up to 10,000 input strings and returns a job_id (HTTP 202).
     - name: extractions
       description: |
-          Extractions endpoint. Extracts elements matching themes with sync (fast=true) and async (fast=false or omitted) modes.
-          - Both modes support up to 200 input strings and up to 50 themes.
+          Extractions endpoint. Extracts elements matching categories with sync (fast=true) and async (fast=false or omitted) modes.
+          - Both modes support up to 200 input strings and up to 50 categories.
           - Synchronous returns immediate results (HTTP 200); asynchronous returns a job_id (HTTP 202).
     - name: jobs
       description: |
@@ -412,9 +412,9 @@ paths:
     /extractions:
         post:
             operationId: extractElements
-            summary: Extract elements matching themes from input strings.
+            summary: Extract elements matching categories from input strings.
             description: |
-                Extracts substrings from inputs that match the provided themes.
+                Extracts substrings from inputs that match the provided categories.
                 Supports synchronous (fast=true) and asynchronous (fast=false or omitted) modes.
 
                  - Both modes support up to 200 text strings and up to 50 categories.

--- a/tests/test_extractions.py
+++ b/tests/test_extractions.py
@@ -1,0 +1,78 @@
+import httpx
+import time
+import warnings
+from pulse.core.client import CoreClient
+from pulse.core.models import ExtractionsResponse
+from pulse.core.jobs import Job
+
+
+def make_sync_client():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/extractions"
+        return httpx.Response(
+            200,
+            json={"extractions": [[["foo"]]], "requestId": "r1"},
+        )
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport, base_url="https://api.example.com")
+    return CoreClient(client=client)
+
+
+def make_async_client():
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path == "/extractions":
+            return httpx.Response(202, json={"jobId": "job123"})
+        if request.method == "GET" and request.url.path == "/jobs":
+            return httpx.Response(
+                200,
+                json={
+                    "jobId": "job123",
+                    "jobStatus": "completed",
+                    "resultUrl": "https://api.example.com/results/job123",
+                },
+            )
+        if request.method == "GET" and request.url.path == "/results/job123":
+            return httpx.Response(
+                200,
+                json={"extractions": [[["bar"]]], "requestId": "r2"},
+            )
+        raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport, base_url="https://api.example.com")
+    return CoreClient(client=client)
+
+
+def test_extract_elements_sync():
+    client = make_sync_client()
+    resp = client.extract_elements(texts=["a"], categories=["b"], fast=True)
+    assert isinstance(resp, ExtractionsResponse)
+    assert resp.extractions[0][0] == ["foo"]
+
+
+def test_extract_elements_async_job(monkeypatch):
+    client = make_async_client()
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    job = client.extract_elements(texts=["a"], categories=["b"], await_job_result=False)
+    assert isinstance(job, Job)
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    result = job.wait()
+    assert result["extractions"][0][0] == ["bar"]
+
+
+def test_extract_elements_async_wait(monkeypatch):
+    client = make_async_client()
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    resp = client.extract_elements(texts=["a"], categories=["b"], await_job_result=True)
+    assert isinstance(resp, ExtractionsResponse)
+    assert resp.extractions[0][0] == ["bar"]
+
+
+def test_extract_elements_themes_deprecation():
+    client = make_sync_client()
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        resp = client.extract_elements(texts=["a"], themes=["b"], fast=True)
+    assert isinstance(resp, ExtractionsResponse)
+    assert any(issubclass(item.category, DeprecationWarning) for item in w)


### PR DESCRIPTION
## Summary
- document text extractions with category fields in OpenAPI
- add tests covering `CoreClient.extract_elements`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68832c4ea714832996d399f184914621