### PR TITLE
Add version and async options for sentiment API

### DIFF
--- a/pulse/core/client.py
+++ b/pulse/core/client.py
@@ -450,14 +450,29 @@ class CoreClient:
         return ThemesResponse.model_validate(data)
 
     def analyze_sentiment(
-        self, texts: list[str], fast: bool = True
+        self,
+        texts: list[str],
+        *,
+        version: str | None = None,
+        fast: bool = True,
+        await_job_result: bool = True,
     ) -> Union[SentimentResponse, Job]:
-        """Classify sentiment."""
-        # Build request body according to OpenAPI spec: input array
+        """Classify sentiment for the given texts.
+
+        Args:
+            texts: List of input strings.
+            version: Optional model version to use.
+            fast: Use synchronous (True) or asynchronous (False) mode.
+            await_job_result: When False, return a :class:`Job` handle instead of
+                waiting for the result.
+        """
+
         body: Dict[str, Any] = {"inputs": texts}
+        if version is not None:
+            body["version"] = version
         if fast:
-            # API expects a JSON boolean for fast
             body["fast"] = True
+
         response = self.client.post("/sentiment", json=body)
         # Raise on any error response
         if response.status_code not in (200, 202):
@@ -467,12 +482,12 @@ class CoreClient:
         # Async job enqueued during fast sync: error
         if response.status_code == 202 and fast:
             raise PulseAPIError(response)
-        # Async job path: wait and parse
         if response.status_code == 202:
-            # Async/job path: initial submission returned only jobId
             submission = JobSubmissionResponse.model_validate(data)
             job = Job(id=submission.jobId, status="pending")
             job._client = self.client
+            if not await_job_result:
+                return job
             result = job.wait()
             return SentimentResponse.model_validate(result)
         # Sync path

--- a/pulse/starters.py
+++ b/pulse/starters.py
@@ -3,12 +3,16 @@ from typing import List, Union
 import pandas as pd
 from typing import Optional
 from pulse.analysis.analyzer import Analyzer
-from pulse.analysis.processes import SentimentProcess, ThemeAllocation
-from pulse.analysis.results import SentimentResult, ThemeAllocationResult
+from pulse.analysis.processes import ThemeAllocation
+from pulse.analysis.results import ThemeAllocationResult
 from pulse.auth import _BaseOAuth2Auth
 from pulse.core.client import CoreClient
 from pulse.core.jobs import Job
-from pulse.core.models import ClusteringResponse, SummariesResponse
+from pulse.core.models import (
+    ClusteringResponse,
+    SentimentResponse,
+    SummariesResponse,
+)
 
 
 def _load_csv_tsv(path: str) -> List[str]:
@@ -49,27 +53,25 @@ def get_strings(source: Union[List[str], str]) -> List[str]:
 
 def sentiment_analysis(
     input_data: Union[List[str], str],
+    *,
+    version: str | None = None,
+    await_job_result: bool = True,
     auth: _BaseOAuth2Auth | None = None,
     client: Optional[CoreClient] = None,
-) -> List[SentimentResult]:
-    """
-    Perform sentiment analysis on input data.
-    Returns a list of SentimentResult objects.
-    """
+) -> Union[SentimentResponse, Job]:
+    """Perform sentiment analysis on input data using the core client."""
+
     texts = get_strings(input_data)
     fast = len(texts) <= 200
 
-    analyzer = Analyzer(
-        processes=[SentimentProcess()],
-        dataset=texts,
-        client=client,
+    client = client or CoreClient(auth=auth)
+
+    return client.analyze_sentiment(
+        texts,
+        version=version,
         fast=fast,
-        auth=auth,
+        await_job_result=await_job_result,
     )
-
-    resp = analyzer.run()
-
-    return resp.sentiment
 
 
 def theme_allocation(

--- a/tests/test_sentiment.py
+++ b/tests/test_sentiment.py
@@ -1,0 +1,76 @@
+import httpx
+import time
+from pulse.core.client import CoreClient
+from pulse.core.models import SentimentResponse
+from pulse.core.jobs import Job
+
+
+def make_sync_client():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/sentiment"
+        import json
+
+        payload = json.loads(request.content.decode())
+        assert payload.get("version") == "v1"
+        data = {
+            "results": [{"sentiment": "positive", "confidence": 0.9}],
+            "requestId": "r1",
+        }
+        return httpx.Response(200, json=data)
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport, base_url="https://api.example.com")
+    return CoreClient(client=client)
+
+
+def make_async_client():
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path == "/sentiment":
+            return httpx.Response(202, json={"jobId": "job123"})
+        if request.method == "GET" and request.url.path == "/jobs":
+            return httpx.Response(
+                200,
+                json={
+                    "jobId": "job123",
+                    "jobStatus": "completed",
+                    "resultUrl": "https://api.example.com/results/job123",
+                },
+            )
+        if request.method == "GET" and request.url.path == "/results/job123":
+            return httpx.Response(
+                200,
+                json={
+                    "results": [{"sentiment": "negative", "confidence": 0.8}],
+                    "requestId": "r2",
+                },
+            )
+        raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport, base_url="https://api.example.com")
+    return CoreClient(client=client)
+
+
+def test_analyze_sentiment_sync():
+    client = make_sync_client()
+    resp = client.analyze_sentiment(["a"], version="v1", fast=True)
+    assert isinstance(resp, SentimentResponse)
+    assert resp.results[0].sentiment == "positive"
+
+
+def test_analyze_sentiment_async_job(monkeypatch):
+    client = make_async_client()
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    job = client.analyze_sentiment(["a"], fast=False, await_job_result=False)
+    assert isinstance(job, Job)
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    result = job.wait()
+    assert result["results"][0]["sentiment"] == "negative"
+
+
+def test_analyze_sentiment_async_wait(monkeypatch):
+    client = make_async_client()
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    resp = client.analyze_sentiment(["a"], fast=False, await_job_result=True)
+    assert isinstance(resp, SentimentResponse)
+    assert resp.results[0].sentiment == "negative"


### PR DESCRIPTION
## Summary
- support version & await_job_result in `CoreClient.analyze_sentiment`
- expose the options through `pulse.starters.sentiment_analysis`
- add unit tests for synchronous and async sentiment

## Testing
- `ruff check pulse tests`
- `black --line-length 88 tests/test_sentiment.py pulse/core/client.py pulse/starters.py`
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_68832d1bfaa083299decfb485ca03a1f