### PR TITLE
Add options to generate_themes

### DIFF
--- a/pulse/analysis/processes.py
+++ b/pulse/analysis/processes.py
@@ -16,8 +16,7 @@ class Process(Protocol):
     id: str
     depends_on: Tuple[str, ...]
 
-    def run(self, ctx: Any) -> Any:
-        ...
+    def run(self, ctx: Any) -> Any: ...
 
 
 class ThemeGeneration:
@@ -31,12 +30,18 @@ class ThemeGeneration:
         min_themes: int = 2,
         max_themes: int = 50,
         context: Any = None,
+        version: str | None = None,
+        prune: int | None = None,
         fast: bool | None = None,
+        await_job_result: bool = True,
     ):
         self.min_themes = min_themes
         self.max_themes = max_themes
         self.context = context
+        self.version = version
+        self.prune = prune
         self.fast = fast
+        self.await_job_result = await_job_result
 
     def run(self, ctx: Any) -> Any:
         texts = ctx.dataset.tolist()
@@ -52,6 +57,10 @@ class ThemeGeneration:
             min_themes=self.min_themes,
             max_themes=self.max_themes,
             fast=self.fast or ctx.fast,
+            context=self.context,
+            version=self.version,
+            prune=self.prune,
+            await_job_result=self.await_job_result,
         )
 
 

--- a/pulse/core/client.py
+++ b/pulse/core/client.py
@@ -402,6 +402,11 @@ class CoreClient:
         min_themes: int = 2,
         max_themes: int = 50,
         fast: bool = True,
+        *,
+        context: Any | None = None,
+        version: str | None = None,
+        prune: int | None = None,
+        await_job_result: bool = True,
     ) -> Union[ThemesResponse, Job]:
         """Cluster texts into latent themes."""
         # Build request body according to OpenAPI spec: inputs and theme options
@@ -415,6 +420,12 @@ class CoreClient:
             body["minThemes"] = min_themes
         if max_themes is not None:
             body["maxThemes"] = max_themes
+        if context is not None:
+            body["context"] = context
+        if version is not None:
+            body["version"] = version
+        if prune is not None:
+            body["prune"] = prune
         # Fast flag for sync vs async
         if fast:
             # API expects a JSON boolean for fast
@@ -444,6 +455,8 @@ class CoreClient:
             submission = JobSubmissionResponse.model_validate(data)
             job = Job(id=submission.jobId, status="pending")
             job._client = self.client
+            if not await_job_result:
+                return job
             result = job.wait()
             return ThemesResponse.model_validate(result)
         # Synchronous response

--- a/pulse/dsl.py
+++ b/pulse/dsl.py
@@ -107,6 +107,8 @@ class Workflow:
         min_themes: int = 2,
         max_themes: int = 10,
         context: Any = None,
+        version: str | None = None,
+        prune: int | None = None,
         fast: bool | None = None,
         source: str | None = None,
         name: str | None = None,
@@ -116,6 +118,8 @@ class Workflow:
             min_themes=min_themes,
             max_themes=max_themes,
             context=context,
+            version=version,
+            prune=prune,
             fast=fast,
         )
         self._add_process(process, name=name)

--- a/tests/test_themes.py
+++ b/tests/test_themes.py
@@ -1,0 +1,82 @@
+import json
+import httpx
+import time
+from pulse.core.client import CoreClient
+from pulse.core.jobs import Job
+from pulse.core.models import ThemesResponse
+
+
+def make_sync_client():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/themes"
+        body = json.loads(request.content.decode())
+        assert body["minThemes"] == 1
+        assert body["maxThemes"] == 3
+        assert body["context"] == "ctx"
+        assert body["version"] == "v1"
+        assert body["prune"] == 2
+        assert body["fast"] is True
+        return httpx.Response(200, json={"themes": [], "requestId": "r1"})
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport, base_url="https://api.example.com")
+    return CoreClient(client=client)
+
+
+def make_async_client():
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path == "/themes":
+            return httpx.Response(202, json={"jobId": "job123"})
+        if request.method == "GET" and request.url.path == "/jobs":
+            return httpx.Response(
+                200,
+                json={
+                    "jobId": "job123",
+                    "jobStatus": "completed",
+                    "resultUrl": "https://api.example.com/results/job123",
+                },
+            )
+        if request.method == "GET" and request.url.path == "/results/job123":
+            return httpx.Response(
+                200,
+                json={
+                    "themes": [],
+                    "requestId": "r2",
+                },
+            )
+        raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport, base_url="https://api.example.com")
+    return CoreClient(client=client)
+
+
+def test_generate_themes_sync():
+    client = make_sync_client()
+    resp = client.generate_themes(
+        ["a", "b"],
+        min_themes=1,
+        max_themes=3,
+        fast=True,
+        context="ctx",
+        version="v1",
+        prune=2,
+    )
+    assert isinstance(resp, ThemesResponse)
+
+
+def test_generate_themes_async_job(monkeypatch):
+    client = make_async_client()
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    job = client.generate_themes(["a", "b"], fast=False, await_job_result=False)
+    assert isinstance(job, Job)
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    result = job.wait()
+    assert result["themes"] == []
+
+
+def test_generate_themes_async_wait(monkeypatch):
+    client = make_async_client()
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    resp = client.generate_themes(["a", "b"], fast=False, await_job_result=True)
+    assert isinstance(resp, ThemesResponse)


### PR DESCRIPTION
## Summary
- extend `CoreClient.generate_themes` with context, version, prune, and await_job_result
- propagate new options through Analyzer process and DSL workflow
- return Job object when not awaiting
- test new parameters and async behaviour

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_68832d216a988329a3b75cd68be47ea6