### PR TITLE
Add version & split options to similarity API

### DIFF
--- a/pulse/core/batching.py
+++ b/pulse/core/batching.py
@@ -19,23 +19,40 @@ def _make_self_chunks(items: List[str]) -> List[List[str]]:
 
 
 def _make_cross_bodies(
-    set_a: List[str], set_b: List[str], flatten: bool
+    set_a: List[str],
+    set_b: List[str],
+    flatten: bool,
+    version: str | None = None,
+    split: Any | None = None,
 ) -> List[Dict[str, Any]]:
-    """Determine request bodies for cross-similarity with batching."""
+    """Determine request bodies for cross-similarity with batching.
+
+    Additional ``version`` and ``split`` parameters are propagated into each
+    request body when provided.
+    """
     A, B = len(set_a), len(set_b)
+
     # If combined size fits
+    def _base_body(a: List[str], b: List[str]) -> Dict[str, Any]:
+        body = {"set_a": a, "set_b": b, "flatten": flatten}
+        if version is not None:
+            body["version"] = version
+        if split is not None:
+            body["split"] = split
+        return body
+
     if A + B <= MAX_ITEMS:
-        return [{"set_a": set_a, "set_b": set_b, "flatten": flatten}]
+        return [_base_body(set_a, set_b)]
 
     # Keep the smaller set intact if possible
     if A <= B < MAX_ITEMS:
         chunk_size = MAX_ITEMS - A
         chunks_b = [set_b[i : i + chunk_size] for i in range(0, B, chunk_size)]
-        return [{"set_a": set_a, "set_b": b, "flatten": flatten} for b in chunks_b]
+        return [_base_body(set_a, b) for b in chunks_b]
     if B <= A < MAX_ITEMS:
         chunk_size = MAX_ITEMS - B
         chunks_a = [set_a[i : i + chunk_size] for i in range(0, A, chunk_size)]
-        return [{"set_a": a, "set_b": set_b, "flatten": flatten} for a in chunks_a]
+        return [_base_body(a, set_b) for a in chunks_a]
 
     # Otherwise, chunk both sets into halves
     chunks_a = [set_a[i : i + HALF_CHUNK] for i in range(0, A, HALF_CHUNK)]
@@ -43,7 +60,7 @@ def _make_cross_bodies(
     bodies: List[Dict[str, Any]] = []
     for a in chunks_a:
         for b in chunks_b:
-            bodies.append({"set_a": a, "set_b": b, "flatten": flatten})
+            bodies.append(_base_body(a, b))
     return bodies
 
 

--- a/pulse/core/client.py
+++ b/pulse/core/client.py
@@ -265,14 +265,18 @@ class CoreClient:
         set_a: list[str] | None = None,
         set_b: list[str] | None = None,
         fast: Optional[bool] = None,
-        flatten: bool = True,
+        flatten: bool = False,
+        version: str | None = None,
+        split: Any | None = None,
+        await_job_result: bool = True,
     ) -> Union[SimilarityResponse, Job]:
-        """
-        Compute cosine similarity.
+        """Compute cosine similarity between strings.
 
-        Must provide exactly one of:
-          - set: list[str]         (self-similarity)
-          - set_a: list[str] and set_b: list[str]   (cross-similarity)
+        Exactly one of ``set`` (self-similarity) or the pair ``set_a``/``set_b``
+        (cross-similarity) must be provided. Optional ``version`` and ``split``
+        values are forwarded to the API. When ``await_job_result`` is ``False``
+        the asynchronous job handle is returned instead of waiting for
+        completion.
         """
         # validate arguments
         if set is None and (set_a is None or set_b is None):
@@ -301,10 +305,16 @@ class CoreClient:
                 set_a=set_a,
                 set_b=set_b,
                 flatten=flatten,
+                version=version,
+                split=split,
             )
 
         # API expects JSON boolean for flatten
         body["flatten"] = flatten
+        if version is not None:
+            body["version"] = version
+        if split is not None:
+            body["split"] = split
 
         if fast:
             # API expects a JSON boolean for fast
@@ -327,10 +337,11 @@ class CoreClient:
 
         # async/job path
         if response.status_code == 202:
-            # Async/job path: initial submission returned only jobId
             submission = JobSubmissionResponse.model_validate(data)
             job = Job(id=submission.jobId, status="pending")
             job._client = self.client
+            if not await_job_result:
+                return job
             result = job.wait(600)
             return SimilarityResponse.model_validate(result)
 
@@ -347,6 +358,11 @@ class CoreClient:
             body["set_b"] = kwargs["set_b"]
         else:
             raise ValueError("Must provide either `set` or both `set_a` and `set_b`.")
+
+        if "version" in kwargs and kwargs["version"] is not None:
+            body["version"] = kwargs["version"]
+        if "split" in kwargs and kwargs["split"] is not None:
+            body["split"] = kwargs["split"]
 
         response = self.client.post("/similarity", json=body)
 
@@ -366,7 +382,9 @@ class CoreClient:
         set: Optional[List[str]] = None,
         set_a: Optional[List[str]] = None,
         set_b: Optional[List[str]] = None,
-        flatten: bool = True,
+        flatten: bool = False,
+        version: str | None = None,
+        split: Any | None = None,
     ) -> Any:
         """
         Batch large similarity requests intelligently under the 10k-item limit.
@@ -378,13 +396,27 @@ class CoreClient:
             for i in range(k):
                 for j in range(i, k):
                     if i == j:
-                        bodies.append({"set": chunks[i], "flatten": flatten})
+                        body = {"set": chunks[i], "flatten": flatten}
+                        if version is not None:
+                            body["version"] = version
+                        if split is not None:
+                            body["split"] = split
+                        bodies.append(body)
                     else:
-                        bodies.append(
-                            {"set_a": chunks[i], "set_b": chunks[j], "flatten": flatten}
-                        )
+                        body = {
+                            "set_a": chunks[i],
+                            "set_b": chunks[j],
+                            "flatten": flatten,
+                        }
+                        if version is not None:
+                            body["version"] = version
+                        if split is not None:
+                            body["split"] = split
+                        bodies.append(body)
         else:
-            bodies = _make_cross_bodies(set_a or [], set_b or [], flatten)
+            bodies = _make_cross_bodies(
+                set_a or [], set_b or [], flatten, version, split
+            )
 
         # submit all jobs
         jobs = [self._submit_batch_similarity_job(**body) for body in bodies]

--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -31,9 +31,17 @@ def test_make_self_chunks_split(monkeypatch):
 def test_make_cross_bodies_combined():
     set_a = list(range(3))
     set_b = list(range(4))
-    bodies = batching._make_cross_bodies(set_a, set_b, flatten=True)
+    bodies = batching._make_cross_bodies(
+        set_a, set_b, flatten=True, version="v1", split="newline"
+    )
     assert len(bodies) == 1
-    assert bodies[0] == {"set_a": set_a, "set_b": set_b, "flatten": True}
+    assert bodies[0] == {
+        "set_a": set_a,
+        "set_b": set_b,
+        "flatten": True,
+        "version": "v1",
+        "split": "newline",
+    }
 
 
 def test_make_cross_bodies_small_a(monkeypatch):
@@ -42,12 +50,16 @@ def test_make_cross_bodies_small_a(monkeypatch):
     monkeypatch.setattr(batching, "HALF_CHUNK", 2)
     set_a = list(range(2))
     set_b = list(range(7))
-    bodies = batching._make_cross_bodies(set_a, set_b, flatten=False)
+    bodies = batching._make_cross_bodies(
+        set_a, set_b, flatten=False, version="v1", split="newline"
+    )
     # chunks_a: 1 chunk, chunks_b: ceil(7/2)=4 chunks
     assert len(bodies) == 4
     for body in bodies:
         assert body["set_a"] == set_a
         assert body["flatten"] is False
+        assert body["version"] == "v1"
+        assert body["split"] == "newline"
 
 
 def test_make_cross_bodies_small_b(monkeypatch):
@@ -56,12 +68,16 @@ def test_make_cross_bodies_small_b(monkeypatch):
     monkeypatch.setattr(batching, "HALF_CHUNK", 2)
     set_a = list(range(4))
     set_b = list(range(2))
-    bodies = batching._make_cross_bodies(set_a, set_b, flatten=True)
+    bodies = batching._make_cross_bodies(
+        set_a, set_b, flatten=True, version="v1", split="newline"
+    )
     # chunks_a: ceil((5-2)=3 => [0:3,3:6]) => 2 chunks, set_b intact
     assert len(bodies) == 2
     for body in bodies:
         assert body["set_b"] == set_b
         assert body["flatten"] is True
+        assert body["version"] == "v1"
+        assert body["split"] == "newline"
 
 
 def test_make_cross_bodies_both_large(monkeypatch):
@@ -70,9 +86,14 @@ def test_make_cross_bodies_both_large(monkeypatch):
     monkeypatch.setattr(batching, "HALF_CHUNK", 2)
     set_a = list(range(7))
     set_b = list(range(7))
-    bodies = batching._make_cross_bodies(set_a, set_b, flatten=False)
+    bodies = batching._make_cross_bodies(
+        set_a, set_b, flatten=False, version="v1", split="newline"
+    )
     # chunks_a: ceil(7/2)=4, chunks_b: 4 => 16 combinations
     assert len(bodies) == 16
+    for body in bodies:
+        assert body["version"] == "v1"
+        assert body["split"] == "newline"
 
 
 def test_stitch_results_self(monkeypatch):

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -1,0 +1,87 @@
+import json
+import time
+import httpx
+from pulse.core.client import CoreClient
+from pulse.core.jobs import Job
+from pulse.core.models import SimilarityResponse
+
+
+def make_sync_client():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/similarity"
+        body = json.loads(request.content.decode())
+        assert body["set"] == ["a", "b"]
+        assert body["version"] == "v1"
+        assert body["split"] == "newline"
+        assert body["fast"] is True
+        assert body["flatten"] is False
+        data = {
+            "scenario": "self",
+            "mode": "flattened",
+            "n": 2,
+            "flattened": [1.0],
+            "requestId": "r1",
+        }
+        return httpx.Response(200, json=data)
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport, base_url="https://api.example.com")
+    return CoreClient(client=client)
+
+
+def make_async_client():
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path == "/similarity":
+            return httpx.Response(202, json={"jobId": "job123"})
+        if request.method == "GET" and request.url.path == "/jobs":
+            return httpx.Response(
+                200,
+                json={
+                    "jobId": "job123",
+                    "jobStatus": "completed",
+                    "resultUrl": "https://api.example.com/results/job123",
+                },
+            )
+        if request.method == "GET" and request.url.path == "/results/job123":
+            return httpx.Response(
+                200,
+                json={
+                    "scenario": "self",
+                    "mode": "flattened",
+                    "n": 2,
+                    "flattened": [0.5],
+                    "requestId": "r2",
+                },
+            )
+        raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport, base_url="https://api.example.com")
+    return CoreClient(client=client)
+
+
+def test_compare_similarity_sync():
+    client = make_sync_client()
+    resp = client.compare_similarity(
+        set=["a", "b"], fast=True, version="v1", split="newline"
+    )
+    assert isinstance(resp, SimilarityResponse)
+    assert resp.n == 2
+
+
+def test_compare_similarity_async_job(monkeypatch):
+    client = make_async_client()
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    job = client.compare_similarity(set=["a", "b"], fast=False, await_job_result=False)
+    assert isinstance(job, Job)
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    result = job.wait()
+    assert result["flattened"] == [0.5]
+
+
+def test_compare_similarity_async_wait(monkeypatch):
+    client = make_async_client()
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    resp = client.compare_similarity(set=["a", "b"], fast=False, await_job_result=True)
+    assert isinstance(resp, SimilarityResponse)
+    assert resp.flattened == [0.5]


### PR DESCRIPTION
## Summary
- extend compare_similarity with optional version, split, flatten, await_job_result
- propagate options through batch helpers and request bodies
- update batching utils and tests for new parameters
- add unit tests covering new compare_similarity behavior

## Testing
- `black .`
- `ruff check pulse tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_688334c0adb48329b460bd1365a575ab