### PR TITLE
Add await_job_result to embeddings endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ from pulse.core.client import CoreClient
 client = CoreClient()  # default to dev environment
 emb = client.create_embeddings(["Hello world", "Goodbye"])  # sync "fast" call
 print(emb.embeddings)
+
+# Submit a long-running job asynchronously
+job = client.create_embeddings(["foo"] * 300, fast=False, await_job_result=False)
+result = job.wait()
 ```
 
 ### CoreClient with Authentication

--- a/pulse/core/client.py
+++ b/pulse/core/client.py
@@ -226,9 +226,16 @@ class CoreClient:
         return cls(base_url=final_base_url, auth=auth)
 
     def create_embeddings(
-        self, inputs: list[str], fast: bool = True
+        self, inputs: list[str], fast: bool = True, *, await_job_result: bool = True
     ) -> Union[EmbeddingsResponse, Job]:
-        """Generate dense vector embeddings."""
+        """Generate dense vector embeddings.
+
+        Args:
+            inputs: Texts to embed.
+            fast: Use synchronous (True) or asynchronous (False) mode.
+            await_job_result: When False, return a :class:`Job` handle instead of
+                waiting for the result when the server responds with HTTP 202.
+        """
 
         # Request body according to OpenAPI spec: inputs
         body: Dict[str, Any] = {"inputs": inputs}
@@ -253,6 +260,8 @@ class CoreClient:
             submission = JobSubmissionResponse.model_validate(data)
             job = Job(id=submission.jobId, status="pending")
             job._client = self.client
+            if not await_job_result:
+                return job
             result = job.wait()
             return EmbeddingsResponse.model_validate(result)
         # Synchronous response

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,0 +1,76 @@
+import json
+import time
+import httpx
+
+from pulse.core.client import CoreClient
+from pulse.core.jobs import Job
+from pulse.core.models import EmbeddingsResponse
+
+
+def make_sync_client():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/embeddings"
+        body = json.loads(request.content.decode())
+        assert body.get("fast") is True
+        data = {
+            "embeddings": [{"text": "a", "vector": [1.0]}],
+            "requestId": "r1",
+        }
+        return httpx.Response(200, json=data)
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport, base_url="https://api.example.com")
+    return CoreClient(client=client)
+
+
+def make_async_client():
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path == "/embeddings":
+            return httpx.Response(202, json={"jobId": "job123"})
+        if request.method == "GET" and request.url.path == "/jobs":
+            return httpx.Response(
+                200,
+                json={
+                    "jobId": "job123",
+                    "jobStatus": "completed",
+                    "resultUrl": "https://api.example.com/results/job123",
+                },
+            )
+        if request.method == "GET" and request.url.path == "/results/job123":
+            return httpx.Response(
+                200,
+                json={
+                    "embeddings": [{"text": "a", "vector": [1.0]}],
+                    "requestId": "r2",
+                },
+            )
+        raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport, base_url="https://api.example.com")
+    return CoreClient(client=client)
+
+
+def test_create_embeddings_sync():
+    client = make_sync_client()
+    resp = client.create_embeddings(["a"], fast=True)
+    assert isinstance(resp, EmbeddingsResponse)
+    assert resp.embeddings[0].text == "a"
+
+
+def test_create_embeddings_async_job(monkeypatch):
+    client = make_async_client()
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    job = client.create_embeddings(["a"], fast=False, await_job_result=False)
+    assert isinstance(job, Job)
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    result = job.wait()
+    assert result["embeddings"][0]["text"] == "a"
+
+
+def test_create_embeddings_async_wait(monkeypatch):
+    client = make_async_client()
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    resp = client.create_embeddings(["a"], fast=False, await_job_result=True)
+    assert isinstance(resp, EmbeddingsResponse)
+    assert resp.embeddings[0].text == "a"


### PR DESCRIPTION
## Summary
- allow CoreClient.create_embeddings() to return a Job when the API responds with 202
- document asynchronous job usage in README
- cover create_embeddings job behaviour with unit tests

## Testing
- `pre-commit run --files pulse/core/client.py tests/test_embeddings.py README.md`
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_688334c2ba0483298a9917912bd5f310