### PR TITLE
Add manual job polling support

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,23 @@ resp = client.extract_elements(
 print(resp.extractions)
 ```
 
+### Polling asynchronous jobs
+
+```python
+import time
+client = CoreClient()
+job = client.analyze_sentiment(["hello"], fast=False, await_job_result=False)
+while True:
+    status = client.get_job_status(job.id)
+    if status.status == "completed":
+        result = client.client.get(status.result_url).json()
+        break
+    time.sleep(1)
+print(result)
+```
+
+`Job.result()` is an alias for `wait()` if you prefer a blocking call.
+
 ### Analyzer
 ```python
 from pulse.analysis.analyzer import Analyzer

--- a/pulse/core/client.py
+++ b/pulse/core/client.py
@@ -510,6 +510,21 @@ class CoreClient:
         """Close underlying HTTP connection."""
         self.client.close()
 
+    def get_job_status(self, job_id: str) -> Job:
+        """Retrieve the status of a previously submitted job."""
+
+        response = self.client.get("/jobs", params={"jobId": job_id})
+        if response.status_code != 200:
+            raise PulseAPIError(response)
+
+        data = response.json()
+        if "jobId" not in data:
+            data["jobId"] = job_id
+
+        job = Job.model_validate(data)
+        job._client = self.client
+        return job
+
     def extract_elements(
         self,
         texts: list[str] | None = None,

--- a/pulse/core/jobs.py
+++ b/pulse/core/jobs.py
@@ -73,3 +73,7 @@ class Job(BaseModel):
             if time.time() - start > timeout:
                 raise TimeoutError(f"Job {self.id} did not finish in {timeout} seconds")
             time.sleep(2.0)
+
+    def result(self, timeout: float = 180.0) -> Any:
+        """Alias for :meth:`wait` for API parity with ``concurrent.futures``."""
+        return self.wait(timeout)

--- a/tests/test_job_polling.py
+++ b/tests/test_job_polling.py
@@ -1,0 +1,75 @@
+import httpx
+import time
+
+from pulse.core.client import CoreClient
+from pulse.core.jobs import Job
+
+
+def make_polling_client():
+    state = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path == "/sentiment":
+            return httpx.Response(202, json={"jobId": "job123"})
+        if request.method == "GET" and request.url.path == "/jobs":
+            state["count"] += 1
+            if state["count"] == 1:
+                return httpx.Response(
+                    200, json={"jobId": "job123", "jobStatus": "pending"}
+                )
+            return httpx.Response(
+                200,
+                json={
+                    "jobId": "job123",
+                    "jobStatus": "completed",
+                    "resultUrl": "https://api.example.com/results/job123",
+                },
+            )
+        if request.method == "GET" and request.url.path == "/results/job123":
+            return httpx.Response(
+                200,
+                json={"results": [{"sentiment": "negative", "confidence": 0.5}]},
+            )
+        raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport, base_url="https://api.example.com")
+    return CoreClient(client=client)
+
+
+def test_get_job_status():
+    client = make_polling_client()
+    job = client.analyze_sentiment(["x"], fast=False, await_job_result=False)
+    status = client.get_job_status(job.id)
+    assert isinstance(status, Job)
+    assert status.status == "pending"
+    status = client.get_job_status(job.id)
+    assert status.status == "completed"
+    assert status.result_url is not None
+
+
+def test_job_result_wrapper(monkeypatch):
+    job = Job(id="job1", status="pending")
+    job._client = httpx.Client()
+
+    called = {}
+
+    def fake_wait(self, timeout=180.0):
+        called["called"] = True
+        return "done"
+
+    monkeypatch.setattr(Job, "wait", fake_wait)
+    assert job.result(1) == "done"
+    assert called.get("called")
+
+
+def test_manual_polling(monkeypatch):
+    client = make_polling_client()
+    job = client.analyze_sentiment(["x"], fast=False, await_job_result=False)
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    while True:
+        status = client.get_job_status(job.id)
+        if status.status == "completed":
+            resp = client.client.get(status.result_url)
+            break
+    assert resp.json()["results"][0]["sentiment"] == "negative"


### PR DESCRIPTION
## Summary
- add `Job.result()` alias for `wait()`
- support `/jobs` polling via `CoreClient.get_job_status`
- document how to poll for job completion
- test new job polling helpers

## Testing
- `ruff check pulse tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688334c9ce908329b934dc76a03c4333