### PR TITLE
Add summarize helper docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,19 @@ resp = client.create_embeddings(["Hello world", "Goodbye"])
 ```python
 from pulse.starters import summarize
 
-texts = ["Great service and friendly staff!", "The app crashed repeatedly."]
-summary = summarize(texts, question="What do people think?")
+# Works with a list of strings or a file path
+summary = summarize("reviews.txt", question="What do people think?")
 print(summary.summary)
+```
+
+### Cluster texts
+
+```python
+from pulse.starters import cluster_analysis
+
+# Cluster comments from a CSV file into two groups
+clusters = cluster_analysis("reviews.csv", k=2)
+print(clusters.clusters)
 ```
 
 ### Extract elements

--- a/pulse/starters.py
+++ b/pulse/starters.py
@@ -111,7 +111,7 @@ def cluster_analysis(
     auth: _BaseOAuth2Auth | None = None,
     client: Optional[CoreClient] = None,
 ) -> Union[ClusteringResponse, Job]:
-    """Cluster input texts using the core API."""
+    """Cluster input texts using the `/clustering` endpoint."""
 
     texts = get_strings(input_data)
     fast = len(texts) <= 200

--- a/tests/test_starters.py
+++ b/tests/test_starters.py
@@ -155,3 +155,24 @@ def test_cluster_analysis():
     resp = cluster_analysis(reviews, k=1, client=fake_client)
 
     assert isinstance(resp, ClusteringResponse)
+
+
+def test_summarize():
+    from pulse.starters import summarize
+    from pulse.core.models import SummariesResponse
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/summaries"
+        return httpx.Response(
+            200,
+            json={"summary": "ok", "requestId": "r1"},
+        )
+
+    transport = httpx.MockTransport(handler)
+    fake_client = CoreClient(
+        client=httpx.Client(transport=transport, base_url="https://api.example.com")
+    )
+
+    resp = summarize(reviews, question="q", client=fake_client)
+
+    assert isinstance(resp, SummariesResponse)


### PR DESCRIPTION
## Summary
- document summarization and clustering helpers in README
- test `summarize` helper
- clarify clustering helper docstring

## Testing
- `pre-commit run --files pulse/starters.py README.md tests/test_starters.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688339290488832982a2c6bd9b06ed75