### PR TITLE
Update docs for new summarization and clustering APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,22 @@ summary = summarize("reviews.txt", question="What do people think?")
 print(summary.summary)
 ```
 
+### Generate summary
+
+```python
+from pulse.core.client import CoreClient
+
+client = CoreClient()
+resp = client.generate_summary(
+    ["Great food, slow service"],
+    "What do diners mention?",
+    length="short",  # optional
+    preset="five-point",  # optional
+    fast=True,
+)
+print(resp.summary)
+```
+
 ### Cluster texts
 
 ```python
@@ -95,6 +111,21 @@ from pulse.starters import cluster_analysis
 # Cluster comments from a CSV file into two groups
 clusters = cluster_analysis("reviews.csv", k=2)
 print(clusters.clusters)
+```
+
+### Cluster texts with CoreClient
+
+```python
+from pulse.core.client import CoreClient
+
+client = CoreClient()
+resp = client.cluster_texts(
+    ["Good", "Bad", "Okay"],
+    k=2,
+    algorithm="skmeans",  # optional
+    fast=True,
+)
+print(resp.clusters)
 ```
 
 ### Extract elements
@@ -180,6 +211,13 @@ results = wf.run()
 print(results.theme_generation.themes)
 print(results.sentiment.sentiments)
 ```
+
+### Optional parameters
+
+- **context** – provide additional context or focus for `generate_themes`.
+- **version** – lock API calls (e.g., `analyze_sentiment`, `generate_themes`) to a specific model version.
+- **algorithm** – choose the clustering algorithm in `cluster_texts`/`cluster_analysis`.
+- **length** and **preset** – control output style in `generate_summary`.
 
 ## Examples
 You can find Jupyter notebooks demonstrating both the high-level and DSL APIs under the `examples/` directory:

--- a/pulse/core/client.py
+++ b/pulse/core/client.py
@@ -449,7 +449,20 @@ class CoreClient:
         prune: int | None = None,
         await_job_result: bool = True,
     ) -> Union[ThemesResponse, Job]:
-        """Cluster texts into latent themes."""
+        """Cluster texts into latent themes.
+
+        Args:
+            texts: Input strings to cluster.
+            min_themes: Minimum number of themes.
+            max_themes: Maximum number of themes.
+            fast: Use synchronous (True) or asynchronous (False) mode.
+            context: Optional context string guiding theme generation.
+            version: Optional model version for reproducible output.
+            prune: Optionally prune the specified number of
+                lowest-frequency themes.
+            await_job_result: When False, return a :class:`Job` handle
+                instead of waiting.
+        """
         # Build request body according to OpenAPI spec: inputs and theme options
         # For single-text input, return empty themes and assignments without API call
         if len(texts) < 2:
@@ -515,7 +528,7 @@ class CoreClient:
 
         Args:
             texts: List of input strings.
-            version: Optional model version to use.
+            version: Optional model version to use for reproducible output.
             fast: Use synchronous (True) or asynchronous (False) mode.
             await_job_result: When False, return a :class:`Job` handle instead of
                 waiting for the result.
@@ -577,7 +590,17 @@ class CoreClient:
         await_job_result: bool = True,
         **legacy_kwargs: Any,
     ) -> Union[ExtractionsResponse, Job]:
-        """Extract elements matching categories from input texts."""
+        """Extract elements matching categories from input texts.
+
+        Args:
+            texts: Input strings to analyze.
+            categories: List of categories or Theme objects.
+            version: Optional model version for reproducible output.
+            dictionary: When True, also include dictionary matches.
+            fast: Use synchronous (True) or asynchronous (False) mode.
+            await_job_result: When False, return a :class:`Job` handle
+                instead of waiting.
+        """
 
         if "inputs" in legacy_kwargs and texts is None:
             texts = legacy_kwargs.pop("inputs")
@@ -637,7 +660,17 @@ class CoreClient:
         fast: bool | None = None,
         await_job_result: bool = True,
     ) -> Union[ClusteringResponse, Job]:
-        """Cluster texts into groups using embeddings."""
+        """Cluster texts into groups using embeddings.
+
+        Args:
+            inputs: Input strings to cluster.
+            k: Desired number of clusters.
+            algorithm: Optional clustering algorithm (``kmeans``, ``skmeans``,
+                ``agglomerative``, ``hdbscan``).
+            fast: Use synchronous (True) or asynchronous (False) mode.
+            await_job_result: When False, return a :class:`Job` handle
+                instead of waiting.
+        """
 
         body: Dict[str, Any] = {"inputs": inputs, "k": k}
         if algorithm is not None:
@@ -675,7 +708,18 @@ class CoreClient:
         fast: bool | None = None,
         await_job_result: bool = True,
     ) -> Union[SummariesResponse, Job]:
-        """Summarize text according to a question."""
+        """Summarize text according to a question.
+
+        Args:
+            inputs: Input strings to summarize.
+            question: Prompt describing the desired summary focus.
+            length: Optional length specifier
+                (``bullet-points``, ``short``, ``medium``, ``long``).
+            preset: Optional preset controlling style.
+            fast: Use synchronous (True) or asynchronous (False) mode.
+            await_job_result: When False, return a :class:`Job` handle
+                instead of waiting.
+        """
 
         body: Dict[str, Any] = {"inputs": inputs, "question": question}
         if length is not None:

--- a/pulse/starters.py
+++ b/pulse/starters.py
@@ -111,7 +111,16 @@ def cluster_analysis(
     auth: _BaseOAuth2Auth | None = None,
     client: Optional[CoreClient] = None,
 ) -> Union[ClusteringResponse, Job]:
-    """Cluster input texts using the `/clustering` endpoint."""
+    """Cluster input texts using the `/clustering` endpoint.
+
+    Args:
+        input_data: List of strings or a path to load strings from.
+        k: Desired number of clusters.
+        algorithm: Optional clustering algorithm to use.
+        await_job_result: When False, return a :class:`Job` handle instead of waiting.
+        auth: Optional authentication object.
+        client: Existing :class:`CoreClient` instance.
+    """
 
     texts = get_strings(input_data)
     fast = len(texts) <= 200
@@ -137,7 +146,17 @@ def summarize(
     auth: _BaseOAuth2Auth | None = None,
     client: Optional[CoreClient] = None,
 ) -> Union[SummariesResponse, Job]:
-    """Generate a summary of the provided texts."""
+    """Generate a summary of the provided texts.
+
+    Args:
+        input_data: List of strings or a file path to load from.
+        question: Prompt describing what to summarize.
+        length: Optional summary length.
+        preset: Optional output preset.
+        await_job_result: When False, return a :class:`Job` handle instead of waiting.
+        auth: Optional authentication object.
+        client: Existing :class:`CoreClient` instance.
+    """
 
     texts = get_strings(input_data)
     fast = len(texts) <= 200


### PR DESCRIPTION
## Summary
- add generate_summary and cluster_texts examples
- document optional parameters in README
- expand CoreClient and starters docstrings with new options

## Testing
- `ruff check pulse tests`
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_68833de5de408329803690409cc28d8f