### PR TITLE
Add VCR tests for new job options

### DIFF
--- a/tests/cassettes/test_analyze_sentiment_job.yaml
+++ b/tests/cassettes/test_analyze_sentiment_job.yaml
@@ -1,0 +1,50 @@
+interactions:
+- request:
+    body: '{"inputs":["happy"]}'
+    headers:
+      authorization:
+      - Bearer testtoken
+    method: POST
+    uri: https://dev.core.researchwiseai.com/pulse/v1/sentiment
+  response:
+    body:
+      string: '{"jobId":"job123"}'
+    headers:
+      Content-Type:
+      - application/json
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: ''
+    headers:
+      authorization:
+      - Bearer testtoken
+    method: GET
+    uri: https://dev.core.researchwiseai.com/pulse/v1/jobs?jobId=job123
+  response:
+    body:
+      string: '{"jobId":"job123","jobStatus":"completed","resultUrl":"https://dev.core.researchwiseai.com/pulse/v1/results/job123"}'
+    headers:
+      Content-Type:
+      - application/json
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      authorization:
+      - Bearer testtoken
+    method: GET
+    uri: https://dev.core.researchwiseai.com/pulse/v1/results/job123
+  response:
+    body:
+      string: '{"results":[{"sentiment":"positive","confidence":0.9}],"requestId":"req8"}'
+    headers:
+      Content-Type:
+      - application/json
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_cluster_texts_fast.yaml
+++ b/tests/cassettes/test_cluster_texts_fast.yaml
@@ -1,0 +1,18 @@
+interactions:
+- request:
+    body: '{"inputs":["foo","bar"],"k":2,"fast":true}'
+    headers:
+      authorization:
+      - Bearer testtoken
+    method: POST
+    uri: https://dev.core.researchwiseai.com/pulse/v1/clustering
+  response:
+    body:
+      string: '{"algorithm":"kmeans","clusters":[{"clusterId":0,"items":["foo"]},{"clusterId":1,"items":["bar"]}],"requestId":"req1"}'
+    headers:
+      Content-Type:
+      - application/json
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_cluster_texts_job.yaml
+++ b/tests/cassettes/test_cluster_texts_job.yaml
@@ -1,0 +1,50 @@
+interactions:
+- request:
+    body: '{"inputs":["foo","bar"],"k":1}'
+    headers:
+      authorization:
+      - Bearer testtoken
+    method: POST
+    uri: https://dev.core.researchwiseai.com/pulse/v1/clustering
+  response:
+    body:
+      string: '{"jobId":"job123"}'
+    headers:
+      Content-Type:
+      - application/json
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: ''
+    headers:
+      authorization:
+      - Bearer testtoken
+    method: GET
+    uri: https://dev.core.researchwiseai.com/pulse/v1/jobs?jobId=job123
+  response:
+    body:
+      string: '{"jobId":"job123","jobStatus":"completed","resultUrl":"https://dev.core.researchwiseai.com/pulse/v1/results/job123"}'
+    headers:
+      Content-Type:
+      - application/json
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      authorization:
+      - Bearer testtoken
+    method: GET
+    uri: https://dev.core.researchwiseai.com/pulse/v1/results/job123
+  response:
+    body:
+      string: '{"algorithm":"kmeans","clusters":[{"clusterId":0,"items":["foo","bar"]}],"requestId":"req2"}'
+    headers:
+      Content-Type:
+      - application/json
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_compare_similarity_job.yaml
+++ b/tests/cassettes/test_compare_similarity_job.yaml
@@ -1,0 +1,50 @@
+interactions:
+- request:
+    body: '{"set":["a","b"],"flatten":false}'
+    headers:
+      authorization:
+      - Bearer testtoken
+    method: POST
+    uri: https://dev.core.researchwiseai.com/pulse/v1/similarity
+  response:
+    body:
+      string: '{"jobId":"job123"}'
+    headers:
+      Content-Type:
+      - application/json
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: ''
+    headers:
+      authorization:
+      - Bearer testtoken
+    method: GET
+    uri: https://dev.core.researchwiseai.com/pulse/v1/jobs?jobId=job123
+  response:
+    body:
+      string: '{"jobId":"job123","jobStatus":"completed","resultUrl":"https://dev.core.researchwiseai.com/pulse/v1/results/job123"}'
+    headers:
+      Content-Type:
+      - application/json
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      authorization:
+      - Bearer testtoken
+    method: GET
+    uri: https://dev.core.researchwiseai.com/pulse/v1/results/job123
+  response:
+    body:
+      string: '{"scenario":"self","mode":"flattened","n":2,"flattened":[0.5],"requestId":"req6"}'
+    headers:
+      Content-Type:
+      - application/json
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_create_embeddings_job.yaml
+++ b/tests/cassettes/test_create_embeddings_job.yaml
@@ -1,0 +1,50 @@
+interactions:
+- request:
+    body: '{"inputs":["a"],"fast":false}'
+    headers:
+      authorization:
+      - Bearer testtoken
+    method: POST
+    uri: https://dev.core.researchwiseai.com/pulse/v1/embeddings
+  response:
+    body:
+      string: '{"jobId":"job123"}'
+    headers:
+      Content-Type:
+      - application/json
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: ''
+    headers:
+      authorization:
+      - Bearer testtoken
+    method: GET
+    uri: https://dev.core.researchwiseai.com/pulse/v1/jobs?jobId=job123
+  response:
+    body:
+      string: '{"jobId":"job123","jobStatus":"completed","resultUrl":"https://dev.core.researchwiseai.com/pulse/v1/results/job123"}'
+    headers:
+      Content-Type:
+      - application/json
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      authorization:
+      - Bearer testtoken
+    method: GET
+    uri: https://dev.core.researchwiseai.com/pulse/v1/results/job123
+  response:
+    body:
+      string: '{"embeddings":[{"text":"a","vector":[1.0]}],"requestId":"req5"}'
+    headers:
+      Content-Type:
+      - application/json
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_extract_elements_job.yaml
+++ b/tests/cassettes/test_extract_elements_job.yaml
@@ -1,0 +1,50 @@
+interactions:
+- request:
+    body: '{"texts":["hello"],"categories":["food"]}'
+    headers:
+      authorization:
+      - Bearer testtoken
+    method: POST
+    uri: https://dev.core.researchwiseai.com/pulse/v1/extractions
+  response:
+    body:
+      string: '{"jobId":"job123"}'
+    headers:
+      Content-Type:
+      - application/json
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: ''
+    headers:
+      authorization:
+      - Bearer testtoken
+    method: GET
+    uri: https://dev.core.researchwiseai.com/pulse/v1/jobs?jobId=job123
+  response:
+    body:
+      string: '{"jobId":"job123","jobStatus":"completed","resultUrl":"https://dev.core.researchwiseai.com/pulse/v1/results/job123"}'
+    headers:
+      Content-Type:
+      - application/json
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      authorization:
+      - Bearer testtoken
+    method: GET
+    uri: https://dev.core.researchwiseai.com/pulse/v1/results/job123
+  response:
+    body:
+      string: '{"extractions":[[["bar"]]],"requestId":"req9"}'
+    headers:
+      Content-Type:
+      - application/json
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_generate_summary_fast.yaml
+++ b/tests/cassettes/test_generate_summary_fast.yaml
@@ -1,0 +1,18 @@
+interactions:
+- request:
+    body: '{"inputs":["foo"],"question":"question","fast":true}'
+    headers:
+      authorization:
+      - Bearer testtoken
+    method: POST
+    uri: https://dev.core.researchwiseai.com/pulse/v1/summaries
+  response:
+    body:
+      string: '{"summary":"bar","requestId":"req3"}'
+    headers:
+      Content-Type:
+      - application/json
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_generate_summary_job.yaml
+++ b/tests/cassettes/test_generate_summary_job.yaml
@@ -1,0 +1,50 @@
+interactions:
+- request:
+    body: '{"inputs":["foo"],"question":"question"}'
+    headers:
+      authorization:
+      - Bearer testtoken
+    method: POST
+    uri: https://dev.core.researchwiseai.com/pulse/v1/summaries
+  response:
+    body:
+      string: '{"jobId":"job123"}'
+    headers:
+      Content-Type:
+      - application/json
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: ''
+    headers:
+      authorization:
+      - Bearer testtoken
+    method: GET
+    uri: https://dev.core.researchwiseai.com/pulse/v1/jobs?jobId=job123
+  response:
+    body:
+      string: '{"jobId":"job123","jobStatus":"completed","resultUrl":"https://dev.core.researchwiseai.com/pulse/v1/results/job123"}'
+    headers:
+      Content-Type:
+      - application/json
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      authorization:
+      - Bearer testtoken
+    method: GET
+    uri: https://dev.core.researchwiseai.com/pulse/v1/results/job123
+  response:
+    body:
+      string: '{"summary":"baz","requestId":"req4"}'
+    headers:
+      Content-Type:
+      - application/json
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_generate_themes_job.yaml
+++ b/tests/cassettes/test_generate_themes_job.yaml
@@ -1,0 +1,50 @@
+interactions:
+- request:
+    body: '{"inputs":["a","b"],"minThemes":1,"maxThemes":3}'
+    headers:
+      authorization:
+      - Bearer testtoken
+    method: POST
+    uri: https://dev.core.researchwiseai.com/pulse/v1/themes
+  response:
+    body:
+      string: '{"jobId":"job123"}'
+    headers:
+      Content-Type:
+      - application/json
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: ''
+    headers:
+      authorization:
+      - Bearer testtoken
+    method: GET
+    uri: https://dev.core.researchwiseai.com/pulse/v1/jobs?jobId=job123
+  response:
+    body:
+      string: '{"jobId":"job123","jobStatus":"completed","resultUrl":"https://dev.core.researchwiseai.com/pulse/v1/results/job123"}'
+    headers:
+      Content-Type:
+      - application/json
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      authorization:
+      - Bearer testtoken
+    method: GET
+    uri: https://dev.core.researchwiseai.com/pulse/v1/results/job123
+  response:
+    body:
+      string: '{"themes":[],"requestId":"req7"}'
+    headers:
+      Content-Type:
+      - application/json
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_core_client.py
+++ b/tests/test_core_client.py
@@ -126,3 +126,74 @@ def test_error_raises():
     client = CoreClient(base_url=base_url, auth=auth)
     with pytest.raises(PulseAPIError):
         client.create_embeddings([False], fast=True)
+
+
+def test_cluster_texts_fast():
+    client = CoreClient(base_url=base_url, auth=auth)
+    resp = client.cluster_texts(["foo", "bar"], k=2, fast=True)
+    assert hasattr(resp, "clusters")
+    assert len(resp.clusters) == 2
+
+
+def test_cluster_texts_job():
+    client = CoreClient(base_url=base_url, auth=auth)
+    job = client.cluster_texts(["foo", "bar"], k=1, await_job_result=False)
+    assert hasattr(job, "id")
+    result = job.wait()
+    assert "clusters" in result
+
+
+def test_generate_summary_fast():
+    client = CoreClient(base_url=base_url, auth=auth)
+    resp = client.generate_summary(["foo"], "question", fast=True)
+    assert hasattr(resp, "summary")
+
+
+def test_generate_summary_job():
+    client = CoreClient(base_url=base_url, auth=auth)
+    job = client.generate_summary(["foo"], "question", await_job_result=False)
+    assert hasattr(job, "id")
+    result = job.wait()
+    assert "summary" in result
+
+
+def test_create_embeddings_job():
+    client = CoreClient(base_url=base_url, auth=auth)
+    job = client.create_embeddings(["a"], fast=False, await_job_result=False)
+    assert hasattr(job, "id")
+    result = job.wait()
+    assert "embeddings" in result
+
+
+def test_compare_similarity_job():
+    client = CoreClient(base_url=base_url, auth=auth)
+    job = client.compare_similarity(set=["a", "b"], fast=False, await_job_result=False)
+    assert hasattr(job, "id")
+    result = job.wait()
+    assert "flattened" in result or "matrix" in result
+
+
+def test_generate_themes_job():
+    client = CoreClient(base_url=base_url, auth=auth)
+    job = client.generate_themes(["a", "b"], await_job_result=False)
+    assert hasattr(job, "id")
+    result = job.wait()
+    assert "themes" in result
+
+
+def test_analyze_sentiment_job():
+    client = CoreClient(base_url=base_url, auth=auth)
+    job = client.analyze_sentiment(["happy"], await_job_result=False)
+    assert hasattr(job, "id")
+    result = job.wait()
+    assert "results" in result
+
+
+def test_extract_elements_job():
+    client = CoreClient(base_url=base_url, auth=auth)
+    job = client.extract_elements(
+        texts=["hello"], categories=["food"], await_job_result=False
+    )
+    assert hasattr(job, "id")
+    result = job.wait()
+    assert "extractions" in result

--- a/tests/test_extractions.py
+++ b/tests/test_extractions.py
@@ -76,3 +76,9 @@ def test_extract_elements_themes_deprecation():
         resp = client.extract_elements(texts=["a"], themes=["b"], fast=True)
     assert isinstance(resp, ExtractionsResponse)
     assert any(issubclass(item.category, DeprecationWarning) for item in w)
+
+
+def test_extract_elements_inputs_compat():
+    client = make_sync_client()
+    resp = client.extract_elements(inputs=["a"], categories=["b"], fast=True)
+    assert isinstance(resp, ExtractionsResponse)


### PR DESCRIPTION
## Summary
- add backward compatibility test for legacy `inputs` arg on `extract_elements`
- record VCR cassettes for `/clustering` and `/summaries`
- expand CoreClient end-to-end tests with async job cases

## Testing
- `pre-commit run --files tests/test_extractions.py tests/test_core_client.py tests/cassettes/test_cluster_texts_fast.yaml tests/cassettes/test_cluster_texts_job.yaml tests/cassettes/test_generate_summary_fast.yaml tests/cassettes/test_generate_summary_job.yaml tests/cassettes/test_create_embeddings_job.yaml tests/cassettes/test_compare_similarity_job.yaml tests/cassettes/test_generate_themes_job.yaml tests/cassettes/test_analyze_sentiment_job.yaml tests/cassettes/test_extract_elements_job.yaml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68833de7cdb08329ad3cede7d29cebe1