### PR TITLE
Update extractions models

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -935,37 +935,48 @@ components:
                     items:
                         type: string
                 dictionary:
+                    type: object
+                    additionalProperties:
+                        type: array
+                        items:
+                            type: string
+                    description: Optional mapping of category to search terms.
+                expand_dictionary:
                     type: boolean
-                    description: 'Enable dictionary-based extraction'
-                version:
-                    type: string
-                fast:
+                    default: true
+                use_ner:
                     type: boolean
-                    description:
-                        Flag indicating synchronous (true) or asynchronous (false) processing.
-                        Default false.
+                    default: true
+                use_llm:
+                    type: boolean
+                    default: true
+                threshold:
+                    type: number
+                    default: 0.5
             required: [texts, categories]
             additionalProperties: false
 
         ExtractionsResponse:
             type: object
             properties:
-                extractions:
+                columns:
                     type: array
-                    description:
-                        3D array of extracted elements, shape [texts.length][categories.length][K]
-                    maxItems: 1000
+                    minItems: 1
+                    items:
+                        type: object
+                        properties:
+                            category:
+                                type: string
+                            term:
+                                type: string
+                        required: [category, term]
+                matrix:
+                    type: array
                     items:
                         type: array
-                        maxItems: 1000
                         items:
-                            type: array
-                            maxItems: 1000
-                            items:
-                                type: string
-                requestId:
-                    type: string
-            required: [extractions, requestId]
+                            type: string
+            required: [columns, matrix]
             additionalProperties: false
 
         SummariesRequest:

--- a/pulse/core/models.py
+++ b/pulse/core/models.py
@@ -162,12 +162,16 @@ class ExtractionsRequest(BaseModel):
     categories: List[str] = Field(
         ..., min_length=1, description="Categories to extract elements for"
     )
-    dictionary: Optional[bool] = Field(
-        None, description="Enable dictionary-based extraction"
+    dictionary: Optional[dict[str, List[str]]] = Field(
+        None, description="Optional mapping of category to search terms"
     )
-    version: Optional[str] = Field(None, description="Extractor version")
-    fast: Optional[bool] = Field(
-        None, description="Synchronous (True) or asynchronous (False)"
+    expand_dictionary: Optional[bool] = Field(
+        None, description="Expand dictionary entries with synonyms"
+    )
+    use_ner: Optional[bool] = Field(None, description="Enable named-entity recognition")
+    use_llm: Optional[bool] = Field(None, description="Enable LLM powered extraction")
+    threshold: Optional[float] = Field(
+        None, description="Score threshold for extraction"
     )
 
     model_config = ConfigDict(populate_by_name=True)
@@ -178,16 +182,23 @@ class ExtractionsRequest(BaseModel):
             values["texts"] = values.pop("inputs")
         if "themes" in values and "categories" not in values:
             values["categories"] = values.pop("themes")
+        # drop deprecated fields from older API versions
+        values.pop("version", None)
+        values.pop("fast", None)
+        if isinstance(values.get("dictionary"), bool):
+            values.pop("dictionary")
         return values
 
 
 class ExtractionsResponse(BaseModel):
     """Response model for text element extraction."""
 
-    extractions: List[List[List[str]]] = Field(
-        ...,
-        description="3D array of extracted elements, shape [texts][categories][k]",
-    )
+    class ExtractionColumn(BaseModel):
+        category: str
+        term: str
+
+    columns: List[ExtractionColumn] = Field(..., description="Column metadata")
+    matrix: List[List[str]] = Field(..., description="Extraction results matrix")
     requestId: Optional[str] = Field(None, description="Unique request identifier")
 
 

--- a/tests/cassettes/test_extract_elements_job.yaml
+++ b/tests/cassettes/test_extract_elements_job.yaml
@@ -40,7 +40,7 @@ interactions:
     uri: https://dev.core.researchwiseai.com/pulse/v1/results/job123
   response:
     body:
-      string: '{"extractions":[[["bar"]]],"requestId":"req9"}'
+      string: '{"columns":[{"category":"food","term":"food"}],"matrix":[["bar"]],"requestId":"req9"}'
     headers:
       Content-Type:
       - application/json

--- a/tests/test_core_client.py
+++ b/tests/test_core_client.py
@@ -196,4 +196,4 @@ def test_extract_elements_job():
     )
     assert hasattr(job, "id")
     result = job.wait()
-    assert "extractions" in result
+    assert "matrix" in result

--- a/tests/test_extractions.py
+++ b/tests/test_extractions.py
@@ -11,7 +11,11 @@ def make_sync_client():
         assert request.url.path == "/extractions"
         return httpx.Response(
             200,
-            json={"extractions": [[["foo"]]], "requestId": "r1"},
+            json={
+                "columns": [{"category": "b", "term": "b"}],
+                "matrix": [["foo"]],
+                "requestId": "r1",
+            },
         )
 
     transport = httpx.MockTransport(handler)
@@ -35,7 +39,11 @@ def make_async_client():
         if request.method == "GET" and request.url.path == "/results/job123":
             return httpx.Response(
                 200,
-                json={"extractions": [[["bar"]]], "requestId": "r2"},
+                json={
+                    "columns": [{"category": "b", "term": "b"}],
+                    "matrix": [["bar"]],
+                    "requestId": "r2",
+                },
             )
         raise AssertionError(f"Unexpected request: {request.method} {request.url}")
 
@@ -48,7 +56,7 @@ def test_extract_elements_sync():
     client = make_sync_client()
     resp = client.extract_elements(texts=["a"], categories=["b"], fast=True)
     assert isinstance(resp, ExtractionsResponse)
-    assert resp.extractions[0][0] == ["foo"]
+    assert resp.matrix[0][0] == "foo"
 
 
 def test_extract_elements_async_job(monkeypatch):
@@ -58,7 +66,7 @@ def test_extract_elements_async_job(monkeypatch):
     assert isinstance(job, Job)
     monkeypatch.setattr(time, "sleep", lambda x: None)
     result = job.wait()
-    assert result["extractions"][0][0] == ["bar"]
+    assert result["matrix"][0][0] == "bar"
 
 
 def test_extract_elements_async_wait(monkeypatch):
@@ -66,7 +74,7 @@ def test_extract_elements_async_wait(monkeypatch):
     monkeypatch.setattr(time, "sleep", lambda x: None)
     resp = client.extract_elements(texts=["a"], categories=["b"], await_job_result=True)
     assert isinstance(resp, ExtractionsResponse)
-    assert resp.extractions[0][0] == ["bar"]
+    assert resp.matrix[0][0] == "bar"
 
 
 def test_extract_elements_themes_deprecation():


### PR DESCRIPTION
## Summary
- update `openapi.yml` extraction schemas
- support new extraction request/response models
- adjust tests for new response shape

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68835f33c8a48329b97e69cad65c05e0