### PR TITLE
Support advanced extraction options

### DIFF
--- a/pulse/analysis/processes.py
+++ b/pulse/analysis/processes.py
@@ -164,10 +164,20 @@ class ThemeExtraction:
         themes: list[str] | None = None,
         version: str | None = None,
         fast: bool | None = None,
+        dictionary: dict[str, list[str]] | None = None,
+        expand_dictionary: bool | None = None,
+        use_ner: bool | None = None,
+        use_llm: bool | None = None,
+        threshold: float | None = None,
     ):
         self.themes = themes
         self.version = version
         self.fast = fast
+        self.dictionary = dictionary
+        self.expand_dictionary = expand_dictionary
+        self.use_ner = use_ner
+        self.use_llm = use_llm
+        self.threshold = threshold
 
     def run(self, ctx: Any) -> Any:
         texts = list(ctx.dataset)
@@ -192,6 +202,11 @@ class ThemeExtraction:
             inputs=texts,
             themes=used_themes,
             version=self.version,
+            dictionary=self.dictionary,
+            expand_dictionary=self.expand_dictionary,
+            use_ner=self.use_ner,
+            use_llm=self.use_llm,
+            threshold=self.threshold,
             fast=self.fast or ctx.fast,
         )
 

--- a/pulse/core/client.py
+++ b/pulse/core/client.py
@@ -1,6 +1,6 @@
 """CoreClient for interacting with the Pulse API synchronously."""
 
-from typing import Any, Dict, List, Union, Optional
+from typing import Any, Dict, List, Union, Optional, Mapping
 import warnings
 import httpx
 from pulse.core.gzip_client import GzipClient
@@ -585,7 +585,11 @@ class CoreClient:
         categories: list[Union[str, Theme]] | None = None,
         *,
         version: str | None = None,
-        dictionary: bool | None = None,
+        dictionary: Mapping[str, list[str]] | None = None,
+        expand_dictionary: bool | None = None,
+        use_ner: bool | None = None,
+        use_llm: bool | None = None,
+        threshold: float | None = None,
         fast: bool | None = None,
         await_job_result: bool = True,
         **legacy_kwargs: Any,
@@ -596,7 +600,11 @@ class CoreClient:
             texts: Input strings to analyze.
             categories: List of categories or Theme objects.
             version: Optional model version for reproducible output.
-            dictionary: When True, also include dictionary matches.
+            dictionary: Optional mapping of categories to search terms.
+            expand_dictionary: Expand dictionary entries with synonyms when ``True``.
+            use_ner: Enable named-entity recognition based extraction.
+            use_llm: Enable LLM-powered extraction.
+            threshold: Score threshold for extraction.
             fast: Use synchronous (True) or asynchronous (False) mode.
             await_job_result: When False, return a :class:`Job` handle
                 instead of waiting.
@@ -628,6 +636,14 @@ class CoreClient:
             body["version"] = version
         if dictionary is not None:
             body["dictionary"] = dictionary
+        if expand_dictionary is not None:
+            body["expand_dictionary"] = expand_dictionary
+        if use_ner is not None:
+            body["use_ner"] = use_ner
+        if use_llm is not None:
+            body["use_llm"] = use_llm
+        if threshold is not None:
+            body["threshold"] = threshold
         if fast is not None:
             body["fast"] = fast
 


### PR DESCRIPTION
## Summary
- extend `CoreClient.extract_elements` to accept synonym expansion, named entity recognition, LLM usage and score threshold
- forward these new options from `ThemeExtraction` process

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_6883623f2bd08329a2821bf390ae9242