### PR TITLE
Support extraction matrix response

### DIFF
--- a/pulse/analysis/results.py
+++ b/pulse/analysis/results.py
@@ -296,18 +296,43 @@ class ThemeExtractionResult:
     @property
     def extractions(self) -> list[list[list[str]]]:
         """Nested list of extracted elements per text per theme."""
-        return self._response.extractions
+        cols = self._response.columns
+        matrix = self._response.matrix
+
+        # map category -> indices of columns belonging to that category
+        cat_to_indices: dict[str, list[int]] = {}
+        for idx, col in enumerate(cols):
+            cat_to_indices.setdefault(col.category, []).append(idx)
+
+        # initialise empty structure
+        result: list[list[list[str]]] = [
+            [[] for _ in self._themes] for _ in range(len(self._texts))
+        ]
+
+        theme_index = {t: i for i, t in enumerate(self._themes)}
+        for i, row in enumerate(matrix):
+            for j, cell in enumerate(row):
+                category = cols[j].category
+                if category not in theme_index:
+                    continue
+                if cell is None or cell == "":
+                    continue
+                items = cell if isinstance(cell, list) else [cell]
+                result[i][theme_index[category]].extend(items)
+
+        return result
 
     def to_dataframe(self) -> pd.DataFrame:
         """Convert extraction results to a DataFrame.
         Columns: text, theme, extraction."""
         rows: list[dict[str, str]] = []
+        nested = self.extractions
         for i, text in enumerate(self._texts):
             for j, theme in enumerate(self._themes):
                 try:
-                    items = self._response.extractions[i][j]
+                    items = nested[i][j]
                 except (IndexError, TypeError):
                     continue
                 for item in items:
-                    rows.append({"text": text, "theme": theme, "extraction": item})
+                    rows.append({"text": text, "category": theme, "extraction": item})
         return pd.DataFrame(rows)

--- a/tests/test_extractions.py
+++ b/tests/test_extractions.py
@@ -56,6 +56,8 @@ def test_extract_elements_sync():
     client = make_sync_client()
     resp = client.extract_elements(texts=["a"], categories=["b"], fast=True)
     assert isinstance(resp, ExtractionsResponse)
+    assert resp.columns[0].category == "b"
+    assert resp.columns[0].term == "b"
     assert resp.matrix[0][0] == "foo"
 
 
@@ -66,6 +68,7 @@ def test_extract_elements_async_job(monkeypatch):
     assert isinstance(job, Job)
     monkeypatch.setattr(time, "sleep", lambda x: None)
     result = job.wait()
+    assert result["columns"][0]["category"] == "b"
     assert result["matrix"][0][0] == "bar"
 
 
@@ -74,6 +77,7 @@ def test_extract_elements_async_wait(monkeypatch):
     monkeypatch.setattr(time, "sleep", lambda x: None)
     resp = client.extract_elements(texts=["a"], categories=["b"], await_job_result=True)
     assert isinstance(resp, ExtractionsResponse)
+    assert resp.columns[0].category == "b"
     assert resp.matrix[0][0] == "bar"
 
 

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -177,3 +177,28 @@ def test_cluster_result_methods():
     # Remove empty labels
     xticks = [lbl for lbl in xticks if lbl]
     assert set(xticks) == set(texts)
+
+
+def test_theme_extraction_result_methods():
+    from pulse.analysis.results import ThemeExtractionResult
+    from pulse.core.models import ExtractionsResponse
+
+    resp = ExtractionsResponse(
+        columns=[
+            ExtractionsResponse.ExtractionColumn(category="Food", term="pizza"),
+            ExtractionsResponse.ExtractionColumn(category="Service", term="svc"),
+        ],
+        matrix=[["pizza", ""], ["", "good"]],
+        requestId=None,
+    )
+    texts = ["I like pizza", "Service was good"]
+    themes = ["Food", "Service"]
+
+    result = ThemeExtractionResult(resp, texts, themes)
+
+    expected = [[["pizza"], []], [[], ["good"]]]
+    assert result.extractions == expected
+
+    df = result.to_dataframe()
+    assert list(df["category"]) == ["Food", "Service"]
+    assert list(df["extraction"]) == ["pizza", "good"]


### PR DESCRIPTION
## Summary
- update `ThemeExtractionResult` to reconstruct the old nested extraction list from the new `matrix`/`columns` schema
- expose reconstructed values in `to_dataframe`
- adjust extraction tests for new schema
- add test coverage for `ThemeExtractionResult`

## Testing
- `pre-commit run --files pulse/analysis/results.py tests/test_extractions.py tests/test_results.py`
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_6883695d901c8329b0bb05d69ff18855