### PR TITLE
Improve PulseAPIError handling

### DIFF
--- a/pulse/core/exceptions.py
+++ b/pulse/core/exceptions.py
@@ -1,14 +1,58 @@
 """Exceptions for Pulse Client API errors."""
 
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import httpx
+
 
 class PulseAPIError(Exception):
     """Represents an error returned by the Pulse API."""
 
-    def __init__(self, response):
-        self.status_code = response.status_code
+    def __init__(self, response: httpx.Response) -> None:
+        self.status: int = response.status_code
+        self.code: Optional[str] = None
+        self.message: Optional[str] = None
         try:
-            detail = response.json()
+            body: Any = response.json()
         except ValueError:
-            detail = response.text
-        super().__init__(f"Status code: {self.status_code}, Detail: {detail}")
-        self.detail = detail
+            body = response.text
+
+        if isinstance(body, dict):
+            self.code = body.get("code")
+            self.message = body.get("message") or response.reason_phrase
+            self.body = body
+        else:
+            self.body = body
+            if isinstance(body, str):
+                self.message = body
+            else:
+                self.message = response.reason_phrase
+
+        super().__init__(str(self))
+
+    def __str__(self) -> str:  # pragma: no cover - simple formatting
+        parts = [f"{self.status}"]
+        if self.code is not None:
+            parts.append(str(self.code))
+        msg = self.message or ""
+        return f"Pulse API Error {' '.join(parts)}: {msg}"
+
+
+class TimeoutError(Exception):
+    """Error thrown when an HTTP request times out."""
+
+    def __init__(self, url: str, timeout: float) -> None:
+        super().__init__(f"Request to {url} timed out after {timeout}ms")
+        self.url = url
+        self.timeout = timeout
+
+
+class NetworkError(Exception):
+    """Error thrown when a network error occurs during a request."""
+
+    def __init__(self, url: str, cause: Exception) -> None:
+        super().__init__(f"Network error while requesting {url}: {cause}")
+        self.url = url
+        self.cause = cause

--- a/tests/test_core_client.py
+++ b/tests/test_core_client.py
@@ -124,8 +124,11 @@ def test_analyze_sentiment_fast():
 
 def test_error_raises():
     client = CoreClient(base_url=base_url, auth=auth)
-    with pytest.raises(PulseAPIError):
+    with pytest.raises(PulseAPIError) as exc:
         client.create_embeddings([False], fast=True)
+    err = exc.value
+    assert err.status == 400
+    assert err.message.startswith("Failed to parse")
 
 
 def test_cluster_texts_fast():


### PR DESCRIPTION
## Summary
- enrich `PulseAPIError` with status, code and message
- expose TimeoutError and NetworkError classes
- verify these fields in unit tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_6883a5a08ea08329ba81a0cdcf4fe446